### PR TITLE
Fix shaders read from file missing newlines

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -122,10 +122,12 @@
         while j))
 
 (defun file->strings (path)
-  (with-open-file (s path)
-    (loop for line = (read-line s nil nil)
-         while line
-         collect line)))
+  "Reads the file into a string.  If there is no newline at the end of the file, one is added."
+  (format nil "~{~A~&~}"
+    (with-open-file (s path)
+      (loop for line = (read-line s nil nil)
+           while line
+           collect line))))
 
 ;; pathnames (from PCL: http://gigamonkeys.com/book/practical-a-portable-pathname-library.html)
 (defun component-present-p (value)


### PR DESCRIPTION
Specifically, in create-shader-from-file and it's variants.

The current implementation removes all the newlines, which causes problems with directives.  See [this Stack Overflow Answer](https://stackoverflow.com/questions/8024433/glsl-shader-compilation-issue-at-runtime/8024613#8024613) for a more detailed explanation.